### PR TITLE
chore(docs): Fixed a couple of typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ zed-sieve/
 ### Manual Installation
 1. Clone this repository:
    ```bash
-   git clone https://github.com/yourusername/zed-sieve
+   git clone https://github.com/aRustyDev/zed-sieve
    cd zed-sieve
    ```
 2. Open Zed
@@ -109,7 +109,7 @@ The extension automatically activates for files with these extensions:
 ### Building from Source
 1. Clone this repository:
    ```bash
-   git clone https://github.com/yourusername/zed-sieve
+   git clone https://github.com/aRustyDev/zed-sieve
    cd zed-sieve
    ```
 


### PR DESCRIPTION
This pull request updates the repository cloning instructions in the `README.md` to use the correct GitHub username. This ensures that users clone the official repository rather than a placeholder.

* Updated the repository URL in both the "Manual Installation" and "Building from Source" sections of `README.md` to use `aRustyDev/zed-sieve` instead of `yourusername/zed-sieve`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L77-R77) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L112-R112)